### PR TITLE
Declare `nonogram_runcycles` in header

### DIFF
--- a/src/obj/nonogram.h
+++ b/src/obj/nonogram.h
@@ -171,6 +171,7 @@ extern "C" {
   int nonogram_runlines_until(nonogram_solver *c, int *lines, clock_t lim);
   int nonogram_runcycles_tries(nonogram_solver *c, int *cycles);
   int nonogram_runcycles_until(nonogram_solver *c, clock_t lim);
+  int nonogram_runcycles(nonogram_solver *c, int (*test)(void *), void *data);
   enum { /* return codes for above calls */
     nonogram_UNLOADED = 0,
     nonogram_FINISHED = 1,

--- a/src/obj/solver.c
+++ b/src/obj/solver.c
@@ -274,8 +274,6 @@ int nonogram_runlines_until(nonogram_solver *c, int *lines, clock_t lim)
   return nonogram_runlines(c, lines, &nonogram_testtime, &lim);
 }
 
-int nonogram_runcycles(nonogram_solver *c, int (*test)(void *), void *data);
-
 int nonogram_runlines(nonogram_solver *c, int *lines,
                       int (*test)(void *), void *data)
 {


### PR DESCRIPTION
`nonogram_runcycles` is documented but not declared in the header. This moves it there (and removes a now-redudant declaration).

I couldn't figure out how to run the tests but this compiles for me, so I think it works.